### PR TITLE
Add ping and network configuration tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ PocketEthernet.
 
 - `main.py`: aplicación principal. Muestra IP, gateway, DNS, velocidad de
   enlace, VLAN detectada y estado PoE. Permite escanear la red y los puertos de
-  los hosts encontrados mediante `nmap`.
+  los hosts encontrados mediante `nmap`. Incluye una pestaña para hacer `ping`
+  a cualquier host y otra para configurar la red de la interfaz seleccionada
+  (DHCP o IP estática).
 - `install.sh`: script para instalar las dependencias necesarias en Raspberry Pi OS o sistemas basados en Debian (incluye `pyroute2` para detectar VLAN).
 
 ## Uso
 
 1. Ejecuta `./install.sh` para instalar Python y todas las dependencias
-   necesarias (incluye `nmap`, `arp-scan` y `pyroute2`).
+   necesarias (incluye `nmap`, `arp-scan`, `iputils-ping` e `iproute2`).
 2. Inicia la interfaz con:
    ```bash
    sudo python3 main.py

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,6 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y python3 python3-pip python3-tk nmap arp-scan
+sudo apt-get install -y python3 python3-pip python3-tk nmap arp-scan iputils-ping iproute2
 
 pip3 install --upgrade netifaces psutil scapy python-nmap pyroute2


### PR DESCRIPTION
## Summary
- add ping and network configuration tabs to GUI
- implement ping and DHCP/static IP configuration logic
- document new features in README
- install additional packages for ping/network configuration

## Testing
- `bash -n install.sh`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684a0cb12fd8832eb96b56a42582db9f