### PR TITLE
Actualizar interfaz con pruebas externas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ PocketEthernet.
 - `main.py`: aplicación principal. Muestra IP, gateway, DNS, velocidad de
   enlace, VLAN detectada, estado PoE y detecta vecinos CDP/LLDP. Permite escanear la red y los puertos de
   los hosts encontrados mediante `nmap`. Incluye una pestaña para hacer `ping`
-  a cualquier host, otra para detectar la **IP externa** consultando un servicio en Internet
-  y otra para configurar la red de la interfaz seleccionada
+  a cualquier host, otra de **pruebas externas** que verifica la conectividad de
+  un puerto TCP y otra para configurar la red de la interfaz seleccionada. La
+  IP pública aparece directamente en la pestaña principal sin necesidad de
+  pulsar ningún botón
   (DHCP o IP estática). La configuración se guarda en `/etc/dhcpcd.conf` para
   que persista tras reiniciar.
 - `install.sh`: script para instalar las dependencias necesarias en Raspberry Pi OS o sistemas basados en Debian (incluye `pyroute2` para detectar VLAN).


### PR DESCRIPTION
## Summary
- mostrar la IP pública en la pestaña principal automáticamente
- reemplazar la pestaña de IP pública por **Pruebas externas** para testear un puerto TCP
- documentar los cambios en README

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684a96e445dc832eb9b8bedb01f15304