### PR TITLE
Fix VLAN interface cleanup on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ PocketEthernet.
   Además, las pestañas de escaneo y ping permiten introducir un ID de VLAN.
   Si se especifica, las pruebas se realizan usando la interfaz etiquetada
   correspondiente (por ejemplo `eth0.10`).
+  Las VLAN temporales creadas para estas pruebas se eliminan automáticamente
+  al iniciar la aplicación para evitar que queden interfaces residuales.
 - `install.sh`: script para instalar las dependencias necesarias en Raspberry Pi OS o sistemas basados en Debian. Emplea el Python obtenido con `which python3` para que las bibliotecas funcionen al ejecutar la aplicación con privilegios (incluye `pyroute2` para detectar VLAN y `ethtool` para el parpadeo de puertos).
 
 ## Uso


### PR DESCRIPTION
## Summary
- add `_is_vlan_interface` helper and `cleanup_vlan_interfaces` to remove leftover VLAN interfaces
- call the cleanup before GUI starts
- document automatic VLAN cleanup in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684aa68bb1a4832eaedd4e450d8a547f