### PR TITLE
Deshabilita campos de red al activar DHCP

### DIFF
--- a/main.py
+++ b/main.py
@@ -925,6 +925,8 @@ class NetworkMonitor(tk.Tk):
         state = "normal" if self.config_mode.get() == "static" else "disabled"
         for widget in (self.ip_entry, self.mask_entry, self.gw_entry, self.dns_entry):
             widget.configure(state=state)
+        if state == "disabled":
+            self.hide_numeric_keypad()
 
     def load_network_config(self):
         """Detect current network configuration for the selected interface."""


### PR DESCRIPTION
## Summary
- hide on-screen keypad and disable IP configuration fields when DHCP is selected

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae7d5e650832ebab376d5ea468bd5