### PR TITLE
Fix keypad flicker and VLAN layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,22 +224,25 @@ class NetworkMonitor(tk.Tk):
         # Scan widgets
         scan_opts = ttk.Frame(self.scan_frame)
         scan_opts.pack(fill="x", pady=2)
-        ttk.Label(scan_opts, text="VLAN ID (opc.):", style="Small.TLabel").grid(row=0, column=0, sticky="w", padx=(0, 5))
+
+        left_scan = ttk.Frame(scan_opts)
+        left_scan.pack(side="left")
+        ttk.Label(left_scan, text="VLAN ID (opc.):", style="Small.TLabel").pack(side="left", padx=(0, 5))
         vcmd = (self.register(self.validate_vlan), "%P")
         self.vlan_entry_scan = ttk.Entry(
-            scan_opts,
+            left_scan,
             textvariable=self.vlan_id_var,
             validate="key",
             validatecommand=vcmd,
             width=8,
         )
-        self.vlan_entry_scan.grid(row=0, column=1, padx=(0, 5), sticky="w")
+        self.vlan_entry_scan.pack(side="left")
         self.vlan_entry_scan.bind("<FocusIn>", lambda e: self.show_numeric_keypad(self.vlan_entry_scan))
 
-        self.scan_button = ttk.Button(scan_opts, text="Escanear red", command=self.scan_network)
-        self.scan_button.grid(row=1, column=0, columnspan=3, pady=5)
-        for i in range(3):
-            scan_opts.columnconfigure(i, weight=1)
+        center_scan = ttk.Frame(scan_opts)
+        center_scan.pack(side="left", expand=True)
+        self.scan_button = ttk.Button(center_scan, text="Escanear red", command=self.scan_network)
+        self.scan_button.pack(pady=5)
 
         columns = ("ip", "mac")
         self.host_tree = ttk.Treeview(self.scan_frame, columns=columns, show="headings", height=8)
@@ -261,21 +264,24 @@ class NetworkMonitor(tk.Tk):
 
         ping_opts = ttk.Frame(self.ping_frame)
         ping_opts.pack(fill="x", pady=2)
-        ttk.Label(ping_opts, text="VLAN ID (opc.):", style="Small.TLabel").grid(row=0, column=0, sticky="w", padx=(0, 5))
+
+        left_ping = ttk.Frame(ping_opts)
+        left_ping.pack(side="left")
+        ttk.Label(left_ping, text="VLAN ID (opc.):", style="Small.TLabel").pack(side="left", padx=(0, 5))
         self.vlan_entry_ping = ttk.Entry(
-            ping_opts,
+            left_ping,
             textvariable=self.vlan_id_var,
             validate="key",
             validatecommand=vcmd,
             width=8,
         )
-        self.vlan_entry_ping.grid(row=0, column=1, padx=(0, 5), sticky="w")
+        self.vlan_entry_ping.pack(side="left")
         self.vlan_entry_ping.bind("<FocusIn>", lambda e: self.show_numeric_keypad(self.vlan_entry_ping))
 
-        self.ping_button = ttk.Button(ping_opts, text="Ping", command=self.run_ping)
-        self.ping_button.grid(row=1, column=0, columnspan=3, pady=5)
-        for i in range(3):
-            ping_opts.columnconfigure(i, weight=1)
+        center_ping = ttk.Frame(ping_opts)
+        center_ping.pack(side="left", expand=True)
+        self.ping_button = ttk.Button(center_ping, text="Ping", command=self.run_ping)
+        self.ping_button.pack(pady=5)
         self.ping_text = tk.Text(self.ping_frame, height=8, font=("Arial", 16))
         self.ping_text.pack(fill="both", expand=True, padx=5, pady=5)
 
@@ -382,6 +388,12 @@ class NetworkMonitor(tk.Tk):
 
     def show_numeric_keypad(self, widget, _event=None):
         """Display on-screen keypad for the focused entry."""
+        if (
+            self.keypad is not None
+            and self.keypad.winfo_exists()
+            and getattr(self.keypad, "entry", None) == widget
+        ):
+            return
         if self.keypad is not None and self.keypad.winfo_exists():
             self.keypad.destroy()
         self.keypad = NumericKeypad(self, widget)


### PR DESCRIPTION
## Summary
- fix flicker caused by keypad recreation on every key press
- align VLAN entry widgets horizontally with action buttons

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ae8f6050c832e97a64f4369cdde60